### PR TITLE
Add ability to configure time axis tick labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # jfreechart-builder
 
-A [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) module for working with the [jfreechart](https://github.com/jfree/jfreechart) library. Meant as a companion to [ChartFactory.java](https://github.com/jfree/jfreechart/blob/master/src/main/java/org/jfree/chart/ChartFactory.java) to build more complex charts with fewer lines of code.
+A [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) module for working with the [jfreechart](https://github.com/jfree/jfreechart) library.
 
-Takes an opinionated approach to creating "good enough" charts while providing a more declarative way of parameterizing them.
+It's a companion to [ChartFactory.java](https://github.com/jfree/jfreechart/blob/master/src/main/java/org/jfree/chart/ChartFactory.java) for using a declarative approach to creating complex charts with fewer lines of code.
+
+
+## Features
+
+* XY time series charts using [CombinedDomainXYPlot](https://github.com/jfree/jfreechart/blob/master/src/main/java/org/jfree/chart/plot/CombinedDomainXYPlot.java) for data alignment on sub-plots
+* Time gap removal solution
+* Time axis tick format control
+* General XY time series charts
+* Stock market OHLC candlestick charts
+* Stock market volume bar charts
+* Overlay series
+* Annotations (arrows, text, lines, boxes)
+* Set various colors
+* Toggle grid lines
+* [Demo app](./demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java) for testing and prototyping
+
+In the future, more facilities may be added to leverage more of what
+[jfreechart](https://github.com/jfree/jfreechart) provides.
 
 
 ## Samples
@@ -99,7 +117,12 @@ ChartBuilder.get()
 
 ![A stock chart time series chart with weekend gaps](./screenshots/stock-chart-time-series-weekend-gaps.png "Screenshot")
 
-Using `showTimeGaps(boolean)` you can remove time gaps that JFreeChart renders by default when no data is defined at expected time instances (like on weekends):
+
+### Time Gap Removal
+
+Implements a solution for removing visible time gaps where no data exists (like on weekends). Accomplishes this with a family of adapter classes mapping `NumberAxis` values as indices in time value arrays.
+
+Configured using `showTimeGaps(boolean)`:
 
 ```
 ChartBuilder.get()
@@ -114,38 +137,34 @@ ChartBuilder.get()
 
 **Note: the x-axis month label in the gapless time chart currently doesn't always correspond to the first day (or trading day) of the month.**
 
+
+### Time Axis Tick Label Formats
+
+You can supply `DateFormat` instances to render time axis tick labels by calling  `dateFormat(DateFormat format)`. You can even implement your own sub-class.
+
+You can also set the vertical label flag to draw them vertically.
+
+
+```
+ChartBuilder.get()
+
+  .dateFormat( /* supply your DateFormat instance here */ )
+
+  .verticalTickLabels(true)
+
+  ...
+```
+
+
+### Convenience Minimal Tick Format
+
+An optional [MinimalDateFormat](./framework/src/main/java/com/jfcbuilder/types/MinimalDateFormat.java) class is implemented to format dates with month letter(s) on first instance of a new month then only month days until a new month is reached.
+
+
 ## Javadoc
 
 See the [Builders Summary](https://matoos32.github.io/jfreechart-builder-docs/javadoc/com/jfcbuilder/builders/package-summary.html)
 to browse the public API.
-
-
-## Capabilities
-
-* XY time series plots using a [CombinedDomainXYPlot](https://github.com/jfree/jfreechart/blob/master/src/main/java/org/jfree/chart/plot/CombinedDomainXYPlot.java) in all cases.
-
-  * This produces left-to-right horizontal time axes and vertical value axes.
-  * The time axis is meant to be shared by all sub-plots.
-  * If you need different time axes then you'll need to `build()` multiple charts and lay those out as desired in your app.
-
-* Stock market OHLC candlestick charts
-
-* Stock market volume bar charts
-
-* Stright line charts
-
-* Overlay series
-
-* Annotations (arrows and text)
-
-* Time gap removal
-
-* Set various colors
-
-* Toggle grid lines
-
-In the future, more parameterization may be added to leverage more of what
-[jfreechart](https://github.com/jfree/jfreechart) provides.
 
 
 ## Demo App
@@ -155,12 +174,14 @@ See the [demo-app](./demo-app) solution for an interactive demo. Used for develo
 
 ## Incorporating into your project
 
+The module is not published to Maven Central so you must build the solution locally and install it in local Maven repositories.
+
 
 ### Prerequisites
 
 * JDK 8 or greater [[1](https://openjdk.java.net/)] [[2](https://www.oracle.com/java/)] installed.
 * [Apache Maven](https://maven.apache.org/) installed.
-* Internet connection for Maven downloads or you add them to your local Maven repo yourself.
+* Internet connection for Maven dependency downloads or you add those to your local Maven repo yourself.
 
 
 ### Installing source code

--- a/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
+++ b/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
@@ -27,12 +27,14 @@ import java.awt.Stroke;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.swing.ButtonGroup;
@@ -67,6 +69,7 @@ import com.jfcbuilder.demo.data.providers.numeric.Sma;
 import com.jfcbuilder.demo.data.providers.numeric.StochasticOscillator;
 import com.jfcbuilder.demo.data.providers.numeric.StochasticOscillator.StochData;
 import com.jfcbuilder.types.DohlcvSeries;
+import com.jfcbuilder.types.MinimalDateFormat;
 
 /**
  * Test class for demonstrating JFreeChartBuilder capabilities. Contains a main application that
@@ -385,27 +388,51 @@ public class JFreeChartBuilderDemo {
   
   private static JFreeChart stockChartDailyWithGaps() {
     return getDailyStockChartBuilder(false)
-      .title("Stock Chart Time Series With Weekend Gaps")
+      .title("Stock Chart Time Series | Weekend Gaps | Default date labels (default locale)")
       .build();
   }
   
   private static JFreeChart stockChartDailyWithGapsWithAnnotations() {
     return getDailyStockChartBuilder(true)
-      .title("Stock Chart Time Series With Weekend Gaps. With Lines and Annotations.")
+      .title("Stock Chart Time Series | Weekend Gaps | Default date labels | Lines and Annotations")
+      .build();
+  }
+  
+  private static JFreeChart stockChartDailyWithGapsCustomDateLabels() {
+    return getDailyStockChartBuilder(false)
+      .title("Stock Chart Time Series | Weekend Gaps | SimpleDateFormat English locale")
+      .dateFormat(new SimpleDateFormat("yy-MMM-dd", Locale.ENGLISH))
+      .verticalTickLabels(true)
+      .build();
+  }
+  
+  private static JFreeChart stockChartDailyWithGapsMinimalDateLabels() {
+    return getDailyStockChartBuilder(false)
+      .title("Stock Chart Time Series | Weekend Gaps | Derived DateFormat (MinimalDateFormat(1) default locale)")
+      .dateFormat(new MinimalDateFormat(1))
       .build();
   }
   
   private static JFreeChart stockChartDailyNoGaps() {
     return getDailyStockChartBuilder(false)
-      .title("Stock Chart Time Series No Weekend Gaps")
+      .title("Stock Chart Time Series | Gapless | Default date labels (MinimalDateFormat(3) default locale)")
       .showTimeGaps(false)
       .build();
   }
-  
+
   private static JFreeChart stockChartDailyNoGapsWithAnnotations() {
     return getDailyStockChartBuilder(true)
-      .title("Stock Chart Time Series No Weekend Gaps. With Lines and Annotations.")
+      .title("Stock Chart Time Series | Gapless | Default date labels | Lines and Annotations")
       .showTimeGaps(false)
+      .build();
+  }
+
+  private static JFreeChart stockChartDailyNoGapsCustomDateLabels() {
+    return getDailyStockChartBuilder(false)
+      .title("Stock Chart Time Series | Gapless | SimpleDateFormat numeric month default locale")
+      .showTimeGaps(false)
+      .dateFormat(new SimpleDateFormat("yy-MM-dd"))
+      .verticalTickLabels(true)
       .build();
   }
 
@@ -415,7 +442,7 @@ public class JFreeChartBuilderDemo {
    * @param args The command line arguments
    */
   public static void main(String[] args) {
-
+    
     List<JFreeChart> charts = new ArrayList<>();
 
     charts.add(simpleTimeSeriesWithAnnotations());
@@ -427,13 +454,20 @@ public class JFreeChartBuilderDemo {
     charts.add(stockChartDailyWithGaps());
 
     charts.add(stockChartDailyWithGapsWithAnnotations());
+    
+    charts.add(stockChartDailyWithGapsCustomDateLabels());
+
+    charts.add(stockChartDailyWithGapsMinimalDateLabels());
 
     charts.add(stockChartDailyNoGaps());
 
     charts.add(stockChartDailyNoGapsWithAnnotations());
 
+    charts.add(stockChartDailyNoGapsCustomDateLabels());
+    
     launchChartDemoWindow(charts);
   }
+
 
   /**
    * Helper method to build a GUI for showcasing the demo charts.
@@ -443,6 +477,7 @@ public class JFreeChartBuilderDemo {
    */
   protected static void launchChartDemoWindow(List<JFreeChart> charts)
       throws HeadlessException {
+
     ChartPanel panel = new ChartPanel(null);
 
     JFrame frame = new JFrame(ChartBuilder.class.getSimpleName() + " Demo App");
@@ -453,9 +488,10 @@ public class JFreeChartBuilderDemo {
 
     JMenuBar menuBar = new JMenuBar();
     frame.setJMenuBar(menuBar);
+
     JMenu demoMenu = new JMenu("Demonstrations");
     menuBar.add(demoMenu);
-
+    
     ButtonGroup group = new ButtonGroup();
     JRadioButtonMenuItem item;
 

--- a/framework/src/main/java/com/jfcbuilder/builders/NumberFormatDateAdapter.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/NumberFormatDateAdapter.java
@@ -1,0 +1,89 @@
+/*
+ * jfreechart-builder-demo: a demonstration app for jfreechart-builder
+ * 
+ * (C) Copyright 2022, by Matt E.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.jfcbuilder.builders;
+
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
+import java.util.Date;
+import java.util.Objects;
+
+import com.jfcbuilder.types.ZeroBasedIndexRange;
+
+/**
+ * Class wrapping {@link DateFormat} to first lookup date values from supplied value indices then double-dispatch the
+ * values to an actual {@link DateFormat}.
+ */
+public class NumberFormatDateAdapter extends NumberFormat {
+
+  private static final long serialVersionUID = 1L;
+  
+  //private int lastIntNum = 0;
+
+  private ZeroBasedIndexRange range;
+  private long[] timeData;
+  private DateFormat dateFormat;
+  
+  public NumberFormatDateAdapter(ZeroBasedIndexRange range, long[] timeData, DateFormat dateFormat) {
+
+    Objects.requireNonNull(range, "Index range not set");
+    Objects.requireNonNull(timeData, "Time data not set");
+    Objects.requireNonNull(dateFormat, "Date format not set");
+
+    this.range = range;
+    this.timeData = timeData;
+    this.dateFormat = dateFormat;
+  }
+  
+  @Override
+  public StringBuffer format(double number, StringBuffer toAppendTo, FieldPosition pos) {
+
+    if (Double.isNaN(number)) {
+      return toAppendTo;
+    }
+
+    final int intNum = (int) number;
+
+    final int timeIndex = range.getStartIndex() + intNum;
+    
+    if ((intNum < 0) || (timeIndex >= timeData.length)) {
+      
+      return toAppendTo;
+
+    } else {
+      
+      return toAppendTo.append(dateFormat.format(new Date(timeData[timeIndex])));
+    }
+  }
+
+  @Override
+  public StringBuffer format(long number, StringBuffer toAppendTo, FieldPosition pos) {
+    return format((double) number, toAppendTo, pos);
+  }
+
+  @Override
+  public Number parse(String source, ParsePosition parsePosition) {
+    // Not supported
+    return null;
+  }
+
+}

--- a/framework/src/main/java/com/jfcbuilder/builders/NumberFormatDateAdapter.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/NumberFormatDateAdapter.java
@@ -1,5 +1,5 @@
 /*
- * jfreechart-builder-demo: a demonstration app for jfreechart-builder
+ * jfreechart-builder: a builder pattern module for working with the jfreechart library
  * 
  * (C) Copyright 2022, by Matt E.
  * 
@@ -30,19 +30,24 @@ import java.util.Objects;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 
 /**
- * Class wrapping {@link DateFormat} to first lookup date values from supplied value indices then double-dispatch the
+ * Class wrapping {@link DateFormat} to first lookup date array values using supplied indices then double-dispatch the
  * values to an actual {@link DateFormat}.
  */
 public class NumberFormatDateAdapter extends NumberFormat {
 
   private static final long serialVersionUID = 1L;
-  
-  //private int lastIntNum = 0;
 
   private ZeroBasedIndexRange range;
   private long[] timeData;
   private DateFormat dateFormat;
-  
+
+  /**
+   * Constructor.
+   * 
+   * @param range      The zero-based indexes defining what elements to actually use in all the configured data sets
+   * @param timeData   Array of date-time data common to all plots. Values are expected to be epoch milliseconds.
+   * @param dateFormat The {@link DateFormat} implementation for converting epoch millisecond values to tick labels
+   */
   public NumberFormatDateAdapter(ZeroBasedIndexRange range, long[] timeData, DateFormat dateFormat) {
 
     Objects.requireNonNull(range, "Index range not set");

--- a/framework/src/main/java/com/jfcbuilder/types/MinimalDateFormat.java
+++ b/framework/src/main/java/com/jfcbuilder/types/MinimalDateFormat.java
@@ -1,0 +1,105 @@
+/*
+ * jfreechart-builder-demo: a demonstration app for jfreechart-builder
+ * 
+ * (C) Copyright 2022, by Matt E.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.jfcbuilder.types;
+
+import java.text.DateFormat;
+import java.text.FieldPosition;
+import java.text.ParsePosition;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+/**
+ * Specialized {@link DateFormat} that generates the first letter(s) of the month for the first axis tick in that month
+ * followed by that new months day number for subsequent ticks. Does not generate time strings.
+ * <p>
+ * To determine if a new month is seen when formatting, class instances are stateful in remembering the last date value
+ * passed to the format method.
+ * <p>
+ * <b>WARNING: No special localization formatting is deliberately done. The first letters of the month obtained for the
+ * default locale settings are used. This generally works for the English language but is perhaps not be suitable for
+ * other languages.</b>
+ */
+public class MinimalDateFormat extends DateFormat {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final int DEFAULT_MONTH_CHARS = 3;
+  
+  private int monthChars;
+  private LocalDate lastDate;
+
+  /**
+   * Constructor using the default number of month label characters.
+   */
+  public MinimalDateFormat() {
+    this(DEFAULT_MONTH_CHARS);
+  }
+  
+  /**
+   * Constructor for using a specific number of month characters. 
+   * 
+   * @param monthChars The number of month characters to display starting from the first letter of the month.
+   * @throws IllegalArgumentException if monthChars is less than one.
+   */
+  public MinimalDateFormat(int monthChars) {
+    
+    if(monthChars < 1) {
+      throw new IllegalArgumentException("Month characters must be at least 1 but " + monthChars + " was specified.");
+    }
+    
+    this.monthChars = monthChars;
+    lastDate = null;
+  }
+
+  @Override
+  public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition fieldPosition) {
+
+    if (date == null) {
+      return toAppendTo;
+    }
+
+    LocalDate currentDate = Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+    
+    StringBuffer strBuf = null;
+
+    if (lastDate != null && currentDate.getMonth() != lastDate.getMonth()) {
+      final String monthStr = currentDate.getMonth().toString();
+      strBuf = toAppendTo
+        .append(monthStr.substring(0, 1).toUpperCase() + monthStr.substring(1, monthChars).toLowerCase());
+
+    } else {
+      strBuf = toAppendTo.append(currentDate.getDayOfMonth());
+    }
+
+    lastDate = currentDate;
+
+    return strBuf;
+  }
+
+  @Override
+  public Date parse(String source, ParsePosition pos) {
+    // Not supported
+    return null;
+  }
+
+}

--- a/framework/src/main/java/com/jfcbuilder/types/MinimalDateFormat.java
+++ b/framework/src/main/java/com/jfcbuilder/types/MinimalDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * jfreechart-builder-demo: a demonstration app for jfreechart-builder
+ * jfreechart-builder: a builder pattern module for working with the jfreechart library
  * 
  * (C) Copyright 2022, by Matt E.
  * 
@@ -30,7 +30,7 @@ import java.util.Date;
 
 /**
  * Specialized {@link DateFormat} that generates the first letter(s) of the month for the first axis tick in that month
- * followed by that new months day number for subsequent ticks. Does not generate time strings.
+ * followed by that new month's day number for subsequent ticks. Does not generate time strings.
  * <p>
  * To determine if a new month is seen when formatting, class instances are stateful in remembering the last date value
  * passed to the format method.


### PR DESCRIPTION
* Adds ChartBuilder ability to set any desired java.text.DateFormat.
* Allows using the Java standard SimpleDateFormat and other DateFormat derived classes in the JDK.
* Extracts previously nested gapless chart logic for custom minimal date format to new MinimalDateFormat class.
* MinimalDateFormat now usable in both gapless and with-gap time series charts.
* Adds ChartBuilder ability to toggle the ValueAxis.setVerticalTickLabels(boolean) on the time axis.
* Updates JFreeChartBuilderDemo demonstration to emphasize locales.