### PR TITLE
Various tech-debt cleanups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's a companion to [ChartFactory.java](https://github.com/jfree/jfreechart/blob
 * General XY time series charts
 * Stock market OHLC candlestick charts
 * Stock market volume bar charts
-* Overlay series
+* Markers
 * Annotations (arrows, text, lines, boxes)
 * Set various colors
 * Toggle grid lines
@@ -96,21 +96,21 @@ ChartBuilder.get()
     .series(XYTimeSeriesBuilder.get().name("MA(200)").data(sma200).color(Color.RED).style(SOLID_LINE))
     .annotation(XYArrowBuilder.get().x(stockEventDate).y(stockEventPrice).angle(270.0).color(DARK_GREEN)
       .textAlign(TextAnchor.BOTTOM_CENTER).text(String.format("%.2f", stockEventPrice)))
-    .line(LineBuilder.get().horizontal().at(resistanceLevel).color(Color.LIGHT_GRAY).style(SOLID_LINE)))
+    .marker(MarkerBuilder.get().horizontal().at(resistanceLevel).color(Color.LIGHT_GRAY).style(SOLID_LINE)))
 
   .xyPlot(VolumeXYPlotBuilder.get().yAxisName("Volume").yTickFormat(volNumFormat).gridLines()
     .series(VolumeXYTimeSeriesBuilder.get().ohlcv(dohlcv).upColor(Color.DARK_GRAY).downColor(Color.RED))
     .series(XYTimeSeriesBuilder.get().name("MA(90)").data(volSma90).color(Color.BLUE).style(SOLID_LINE))
     .annotation(XYArrowBuilder.get().x(stockEventDate).y(stockEventVolume).angle(270.0).color(DARK_GREEN)
       .textAlign(TextAnchor.BOTTOM_CENTER).text(String.format("%.0f", stockEventVolume)))
-    .line(LineBuilder.get().horizontal().at(volumeLine).color(DARK_GREEN).style(SOLID_LINE)))
+    .marker(MarkerBuilder.get().horizontal().at(volumeLine).color(DARK_GREEN).style(SOLID_LINE)))
 
   .xyPlot(XYTimeSeriesPlotBuilder.get().yAxisName("Stoch").yAxisRange(0.0, 100.0).yAxisTickSize(50.0).gridLines()
     .series(XYTimeSeriesBuilder.get().name("K(" + K + ")").data(stoch.getPctK()).color(Color.RED).style(SOLID_LINE))
     .series(XYTimeSeriesBuilder.get().name("D(" + D + ")").data(stoch.getPctD()).color(Color.BLUE).style(SOLID_LINE))
-    .line(LineBuilder.get().horizontal().at(80.0).color(Color.BLACK).style(SOLID_LINE))
-    .line(LineBuilder.get().horizontal().at(50.0).color(Color.BLUE).style(SOLID_LINE))
-    .line(LineBuilder.get().horizontal().at(20.0).color(Color.BLACK).style(SOLID_LINE)))
+    .marker(MarkerBuilder.get().horizontal().at(80.0).color(Color.BLACK).style(SOLID_LINE))
+    .marker(MarkerBuilder.get().horizontal().at(50.0).color(Color.BLUE).style(SOLID_LINE))
+    .marker(MarkerBuilder.get().horizontal().at(20.0).color(Color.BLACK).style(SOLID_LINE)))
 
   .build();
 ```

--- a/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
+++ b/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
@@ -47,16 +47,15 @@ import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.ui.TextAnchor;
 
-import com.jfcbuilder.builders.BuilderConstants;
 import com.jfcbuilder.builders.ChartBuilder;
-import com.jfcbuilder.builders.LineBuilder;
+import com.jfcbuilder.builders.MarkerBuilder;
 import com.jfcbuilder.builders.OhlcPlotBuilder;
 import com.jfcbuilder.builders.OhlcSeriesBuilder;
 import com.jfcbuilder.builders.VolumeXYPlotBuilder;
 import com.jfcbuilder.builders.VolumeXYTimeSeriesBuilder;
 import com.jfcbuilder.builders.XYArrowBuilder;
 import com.jfcbuilder.builders.XYBoxBuilder;
-import com.jfcbuilder.builders.XYLineAnnotationBuilder;
+import com.jfcbuilder.builders.XYLineBuilder;
 import com.jfcbuilder.builders.XYTextBuilder;
 import com.jfcbuilder.builders.XYTimeSeriesBuilder;
 import com.jfcbuilder.builders.XYTimeSeriesPlotBuilder;
@@ -68,6 +67,7 @@ import com.jfcbuilder.demo.data.providers.numeric.Sinusoid;
 import com.jfcbuilder.demo.data.providers.numeric.Sma;
 import com.jfcbuilder.demo.data.providers.numeric.StochasticOscillator;
 import com.jfcbuilder.demo.data.providers.numeric.StochasticOscillator.StochData;
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.DohlcvSeries;
 import com.jfcbuilder.types.MinimalDateFormat;
 
@@ -275,9 +275,9 @@ public class JFreeChartBuilderDemo {
       .yAxisName("Stochastics(" + K + ", " + D + ")")
       .series(XYTimeSeriesBuilder.get().data(stoch.getPctK()).color(Color.RED).style(SOLID_LINE))
       .series(XYTimeSeriesBuilder.get().data(stoch.getPctD()).color(Color.BLUE).style(SOLID_LINE))
-      .line(LineBuilder.get().horizontal().at(80.0).color(Color.BLACK).style(SOLID_LINE))
-      .line(LineBuilder.get().horizontal().at(50.0).color(Color.BLUE).style(SOLID_LINE))
-      .line(LineBuilder.get().horizontal().at(20.0).color(Color.BLACK).style(SOLID_LINE));
+      .marker(MarkerBuilder.get().horizontal().at(80.0).color(Color.BLACK).style(SOLID_LINE))
+      .marker(MarkerBuilder.get().horizontal().at(50.0).color(Color.BLUE).style(SOLID_LINE))
+      .marker(MarkerBuilder.get().horizontal().at(20.0).color(Color.BLACK).style(SOLID_LINE));
     
     if (annotate) {
 
@@ -319,7 +319,7 @@ public class JFreeChartBuilderDemo {
           .arrowLength(40.0).tipRadius(3.0)
           .color(DARK_GREEN))
 
-        .annotation(XYLineAnnotationBuilder.get()
+        .annotation(XYLineBuilder.get()
           .x1(p1Date).y1(p1Price)
           .x2(p2Date).y2(p2Price)
           .color(Color.MAGENTA).style(THICK_DASHED_LINE))
@@ -330,7 +330,7 @@ public class JFreeChartBuilderDemo {
           .outlineStyle(SOLID_LINE).outlineColor(TRANSPARENT_DARK_GREEN)
           .fillColor(TRANSPARENT_GREEN))
         
-        .line(LineBuilder.get().horizontal().at(resistanceLevel)
+        .marker(MarkerBuilder.get().horizontal().at(resistanceLevel)
           .color(Color.LIGHT_GRAY).style(SOLID_LINE));
 
 
@@ -343,7 +343,7 @@ public class JFreeChartBuilderDemo {
           .arrowLength(30.0).tipRadius(4.0)
           .color(DARK_GREEN))
 
-        .annotation(XYLineAnnotationBuilder.get()
+        .annotation(XYLineBuilder.get()
           .x1(p1Date).y1(p1Volume)
           .x2(p2Date).y2(p2Volume)
           .color(Color.MAGENTA).style(THICK_DASHED_LINE))
@@ -354,7 +354,7 @@ public class JFreeChartBuilderDemo {
           .outlineStyle(THICK_DASHED_LINE).outlineColor(Color.CYAN)
           .fillColor(Color.YELLOW))
         
-        .line(LineBuilder.get().horizontal().at(volumeLine)
+        .marker(MarkerBuilder.get().horizontal().at(volumeLine)
           .color(DARK_GREEN).style(SOLID_LINE));
 
 
@@ -366,7 +366,7 @@ public class JFreeChartBuilderDemo {
           .angle(90.0).textAlign(TextAnchor.BOTTOM_CENTER).textPaddingLeft(5)
           .color(DARK_GREEN))
   
-        .annotation(XYLineAnnotationBuilder.get()
+        .annotation(XYLineBuilder.get()
           .x1(p1Date).y1(p1Stoch)
           .x2(p2Date).y2(p2Stoch)
           .color(Color.MAGENTA).style(THICK_DASHED_LINE))
@@ -394,7 +394,7 @@ public class JFreeChartBuilderDemo {
   
   private static JFreeChart stockChartDailyWithGapsWithAnnotations() {
     return getDailyStockChartBuilder(true)
-      .title("Stock Chart Time Series | Weekend Gaps | Default date labels | Lines and Annotations")
+      .title("Stock Chart Time Series | Weekend Gaps | Default date labels | Markers and Annotations")
       .build();
   }
   
@@ -422,7 +422,7 @@ public class JFreeChartBuilderDemo {
 
   private static JFreeChart stockChartDailyNoGapsWithAnnotations() {
     return getDailyStockChartBuilder(true)
-      .title("Stock Chart Time Series | Gapless | Default date labels | Lines and Annotations")
+      .title("Stock Chart Time Series | Gapless | Default date labels | Markers and Annotations")
       .showTimeGaps(false)
       .build();
   }

--- a/framework/src/main/java/com/jfcbuilder/adapters/INumberMappedCollection.java
+++ b/framework/src/main/java/com/jfcbuilder/adapters/INumberMappedCollection.java
@@ -18,12 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.adapters;
 
 /**
  * Interface for all wrappers that map a collection's values to x-axis index numbers.
  */
-interface INumberMappedCollection {
+public interface INumberMappedCollection {
 
   /**
    * Returns a series item's x-value element index as a double instead of the x-value itself.

--- a/framework/src/main/java/com/jfcbuilder/adapters/NumberFormatDateAdapter.java
+++ b/framework/src/main/java/com/jfcbuilder/adapters/NumberFormatDateAdapter.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.adapters;
 
 import java.text.DateFormat;
 import java.text.FieldPosition;

--- a/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedOHLCSeriesCollection.java
+++ b/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedOHLCSeriesCollection.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.adapters;
 
 import java.util.Objects;
 
@@ -32,7 +32,7 @@ import org.jfree.data.xy.OHLCDataset;
 /**
  * Wrapper for OHLCSeriesCollection to map timestamp values to x-axis numeric indexes.
  */
-class NumberMappedOHLCSeriesCollection implements OHLCDataset, INumberMappedCollection {
+public class NumberMappedOHLCSeriesCollection implements OHLCDataset, INumberMappedCollection {
 
   private OHLCSeriesCollection collection;
   

--- a/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedTimeSeriesCollection.java
+++ b/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedTimeSeriesCollection.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.adapters;
 
 import org.jfree.data.time.RegularTimePeriod;
 import org.jfree.data.time.TimePeriodAnchor;
@@ -27,7 +27,7 @@ import org.jfree.data.time.TimeSeriesCollection;
 /**
  * Extension to TimeSeriesCollection to map timestamp values to x-axis numeric indexes.
  */
-class NumberMappedTimeSeriesCollection extends TimeSeriesCollection
+public class NumberMappedTimeSeriesCollection extends TimeSeriesCollection
     implements INumberMappedCollection {
 
   /**

--- a/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedXYBarRenderer.java
+++ b/framework/src/main/java/com/jfcbuilder/adapters/NumberMappedXYBarRenderer.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.adapters;
 
 import java.awt.Graphics2D;
 import java.awt.Paint;
@@ -35,11 +35,13 @@ import org.jfree.chart.ui.RectangleEdge;
 import org.jfree.data.xy.IntervalXYDataset;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.types.BuilderConstants;
+
 /**
  * Specialized renderer for rendering XY bars when they have x-axis values mapped to a numeric
  * scale.
  */
-class NumberMappedXYBarRenderer extends XYBarRenderer {
+public class NumberMappedXYBarRenderer extends XYBarRenderer {
 
   /**
    * Generated value

--- a/framework/src/main/java/com/jfcbuilder/builders/BuilderUtils.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/BuilderUtils.java
@@ -30,10 +30,13 @@ import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.types.BuilderConstants;
+import com.jfcbuilder.types.XYTimeSeriesPlotBuilderElements;
+
 /**
  * Utility methods that can be used throughout the application.
  */
-abstract class BuilderUtils {
+public abstract class BuilderUtils {
 
   /**
    * Factory method for getting new instances of the default axis number format.

--- a/framework/src/main/java/com/jfcbuilder/builders/CandlestickRendererBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/CandlestickRendererBuilder.java
@@ -25,10 +25,12 @@ import java.util.Objects;
 
 import org.jfree.chart.renderer.xy.CandlestickRenderer;
 
+import com.jfcbuilder.types.BuilderConstants;
+
 /**
  * Builder for creating configured CandlestickRenderer instances.
  */
-class CandlestickRendererBuilder {
+public class CandlestickRendererBuilder {
 
   private Color upColor;
   private Color downColor;

--- a/framework/src/main/java/com/jfcbuilder/builders/ChartBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/ChartBuilder.java
@@ -40,6 +40,8 @@ import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.data.time.Millisecond;
 import org.jfree.data.time.RegularTimePeriod;
 
+import com.jfcbuilder.adapters.NumberFormatDateAdapter;
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.MinimalDateFormat;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 

--- a/framework/src/main/java/com/jfcbuilder/builders/IXYAnnotationBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/IXYAnnotationBuilder.java
@@ -33,7 +33,7 @@ import org.jfree.chart.annotations.XYAnnotation;
  * @param <T> The method chaining return type, which must be the type of the builder implementing
  *        this interface.
  */
-interface IXYAnnotationBuilder<T extends IXYAnnotationBuilder<T>> {
+public interface IXYAnnotationBuilder<T extends IXYAnnotationBuilder<T>> {
 
   /**
    * Builds the XYAnnotation from all configured data and properties.

--- a/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesBuilder.java
@@ -38,7 +38,7 @@ import com.jfcbuilder.types.ZeroBasedIndexRange;
  * @param <T> The method chaining return type, which must be the type of the builder implementing
  *        this interface.
  */
-interface IXYTimeSeriesBuilder<T extends IXYTimeSeriesBuilder<T>> {
+public interface IXYTimeSeriesBuilder<T extends IXYTimeSeriesBuilder<T>> {
 
   /**
    * Sets the name associated with the series.

--- a/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesDatasetBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesDatasetBuilder.java
@@ -35,7 +35,7 @@ import com.jfcbuilder.types.ZeroBasedIndexRange;
  * @param <T> The method chaining return type, which must be the type of the builder implementing
  *        this interface.
  */
-interface IXYTimeSeriesDatasetBuilder<T extends IXYTimeSeriesDatasetBuilder<T>> {
+public interface IXYTimeSeriesDatasetBuilder<T extends IXYTimeSeriesDatasetBuilder<T>> {
 
   /**
    * Sets the time data to be used for generating the XYDataset.

--- a/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesPlotBuilder.java
@@ -39,7 +39,7 @@ import com.jfcbuilder.types.ZeroBasedIndexRange;
  * @param <T> The method chaining return type, which must be the type of the builder implementing
  *        this interface.
  */
-interface IXYTimeSeriesPlotBuilder<T extends IXYTimeSeriesPlotBuilder<T>> {
+public interface IXYTimeSeriesPlotBuilder<T extends IXYTimeSeriesPlotBuilder<T>> {
 
   /**
    * Sets the date-time values to be used when building the plot.
@@ -94,13 +94,13 @@ interface IXYTimeSeriesPlotBuilder<T extends IXYTimeSeriesPlotBuilder<T>> {
   T series(IXYTimeSeriesDatasetBuilder<?> series);
 
   /**
-   * Registers a LineBuilder whose {@code build()} method will be called to generate its plot line
+   * Registers a {@link MarkerBuilder} whose {@code build()} method will be called to generate its plot line
    * when this plot builder's{@code build()} method is called.
    * 
-   * @param line The line builder representing the line that it will build
+   * @param marker The marker builder representing the marker that it will build
    * @return Reference to this builder instance for method chaining
    */
-  T line(LineBuilder line);
+  T marker(MarkerBuilder marker);
 
   /**
    * Registers an IXYAnnotationBuilder whose {@code build()} method will be called to generate its

--- a/framework/src/main/java/com/jfcbuilder/builders/MarkerBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/MarkerBuilder.java
@@ -25,12 +25,13 @@ import java.awt.Stroke;
 
 import org.jfree.chart.plot.ValueMarker;
 
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.Orientation;
 
 /**
- * Uses configured properties to Build a ValueMarker representing a plot overlay line.
+ * Uses configured properties to Build a {@link ValueMarker} representing a plot overlay line.
  */
-public class LineBuilder {
+public class MarkerBuilder {
 
   private static final double DEFAULT_VALUE = 0.0;
 
@@ -42,7 +43,7 @@ public class LineBuilder {
   /**
    * Hidden constructor.
    */
-  private LineBuilder() {
+  private MarkerBuilder() {
     orientation = BuilderConstants.DEFAULT_ORIENTATION;
     value = DEFAULT_VALUE;
     color = BuilderConstants.DEFAULT_LINE_COLOR;
@@ -54,8 +55,8 @@ public class LineBuilder {
    * 
    * @return New instance of this class
    */
-  public static LineBuilder get() {
-    return new LineBuilder();
+  public static MarkerBuilder get() {
+    return new MarkerBuilder();
   }
 
   /**
@@ -64,7 +65,7 @@ public class LineBuilder {
    * @param orientation The desired orientation of the line
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder orientation(Orientation orientation) {
+  public MarkerBuilder orientation(Orientation orientation) {
     this.orientation = orientation;
     return this;
   }
@@ -74,7 +75,7 @@ public class LineBuilder {
    * 
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder horizontal() {
+  public MarkerBuilder horizontal() {
     this.orientation = Orientation.HORIZONTAL;
     return this;
   }
@@ -84,7 +85,7 @@ public class LineBuilder {
    * 
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder vertical() {
+  public MarkerBuilder vertical() {
     this.orientation = Orientation.VERTICAL;
     return this;
   }
@@ -104,7 +105,7 @@ public class LineBuilder {
    * @param value The desired line value
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder at(double value) {
+  public MarkerBuilder at(double value) {
     this.value = value;
     return this;
   }
@@ -115,7 +116,7 @@ public class LineBuilder {
    * @param color The desired color
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder color(Color color) {
+  public MarkerBuilder color(Color color) {
     this.color = color;
     return this;
   }
@@ -126,7 +127,7 @@ public class LineBuilder {
    * @param style The desired line style
    * @return Reference to this builder for chaining method calls
    */
-  public LineBuilder style(Stroke style) {
+  public MarkerBuilder style(Stroke style) {
     this.style = style;
     return this;
   }

--- a/framework/src/main/java/com/jfcbuilder/builders/OhlcPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/OhlcPlotBuilder.java
@@ -36,7 +36,11 @@ import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.time.ohlc.OHLCSeriesCollection;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.adapters.NumberMappedOHLCSeriesCollection;
+import com.jfcbuilder.adapters.NumberMappedTimeSeriesCollection;
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.Orientation;
+import com.jfcbuilder.types.XYTimeSeriesPlotBuilderElements;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 
 /**
@@ -128,8 +132,8 @@ public class OhlcPlotBuilder implements IXYTimeSeriesPlotBuilder<OhlcPlotBuilder
   }
 
   @Override
-  public OhlcPlotBuilder line(LineBuilder line) {
-    elements.line(line);
+  public OhlcPlotBuilder marker(MarkerBuilder line) {
+    elements.marker(line);
     return this;
   }
 
@@ -287,7 +291,7 @@ public class OhlcPlotBuilder implements IXYTimeSeriesPlotBuilder<OhlcPlotBuilder
 
     }
 
-    for (LineBuilder builder : elements.unmodifiableLines()) {
+    for (MarkerBuilder builder : elements.unmodifiableLines()) {
       ValueMarker line = builder.build();
 
       if (builder.orientation() == Orientation.HORIZONTAL) {

--- a/framework/src/main/java/com/jfcbuilder/builders/OhlcSeriesBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/OhlcSeriesBuilder.java
@@ -30,6 +30,7 @@ import org.jfree.data.time.ohlc.OHLCSeries;
 import org.jfree.data.time.ohlc.OHLCSeriesCollection;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.OhlcvSeries;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 

--- a/framework/src/main/java/com/jfcbuilder/builders/VolumeXYPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/VolumeXYPlotBuilder.java
@@ -25,6 +25,8 @@ import java.awt.Color;
 import org.jfree.chart.renderer.xy.CandlestickRenderer;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.types.BuilderConstants;
+
 /**
  * Builder for producing stock market volume plots using configured builder properties, series, and
  * datasets. Extends OhlcPlotBuilder to leverage it's bar drawing logic and to ensure bars in the

--- a/framework/src/main/java/com/jfcbuilder/builders/VolumeXYTimeSeriesBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/VolumeXYTimeSeriesBuilder.java
@@ -30,6 +30,7 @@ import org.jfree.data.time.ohlc.OHLCSeries;
 import org.jfree.data.time.ohlc.OHLCSeriesCollection;
 import org.jfree.data.xy.XYDataset;
 
+import com.jfcbuilder.types.BuilderConstants;
 import com.jfcbuilder.types.OhlcvSeries;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 

--- a/framework/src/main/java/com/jfcbuilder/builders/XYArrowBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYArrowBuilder.java
@@ -27,6 +27,8 @@ import org.jfree.chart.annotations.XYAnnotation;
 import org.jfree.chart.annotations.XYPointerAnnotation;
 import org.jfree.chart.ui.TextAnchor;
 
+import com.jfcbuilder.types.XYTextAnnotationElements;
+
 /**
  * Builder for producing {@link XYPointerAnnotation} (arrow) objects.
  */

--- a/framework/src/main/java/com/jfcbuilder/builders/XYLineBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYLineBuilder.java
@@ -27,10 +27,12 @@ import java.util.Arrays;
 import org.jfree.chart.annotations.XYAnnotation;
 import org.jfree.chart.annotations.XYLineAnnotation;
 
+import com.jfcbuilder.types.BuilderConstants;
+
 /**
  * Builder for producing {@link XYLineAnnotation} objects.
  */
-public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnotationBuilder> {
+public class XYLineBuilder implements IXYAnnotationBuilder<XYLineBuilder> {
 
   private double x1;
   private double y1;
@@ -42,7 +44,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
   /**
    * Hidden constructor.
    */
-  private XYLineAnnotationBuilder() {
+  private XYLineBuilder() {
     x1 = Double.NaN;
     y1 = Double.NaN;
     x2 = Double.NaN;
@@ -56,15 +58,15 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
    * 
    * @return New instance of this class
    */
-  public static XYLineAnnotationBuilder get() {
-    return new XYLineAnnotationBuilder();
+  public static XYLineBuilder get() {
+    return new XYLineBuilder();
   }
   
   public double x1() {
     return x1;
   }
 
-  public XYLineAnnotationBuilder x1(double x1) {
+  public XYLineBuilder x1(double x1) {
     this.x1 = x1;
     return this;
   }
@@ -73,7 +75,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
     return y1;
   }
 
-  public XYLineAnnotationBuilder y1(double y1) {
+  public XYLineBuilder y1(double y1) {
     this.y1 = y1;
     return this;
   }
@@ -82,7 +84,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
     return x2;
   }
 
-  public XYLineAnnotationBuilder x2(double x2) {
+  public XYLineBuilder x2(double x2) {
     this.x2 = x2;
     return this;
   }
@@ -91,7 +93,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
     return y2;
   }
 
-  public XYLineAnnotationBuilder y2(double y2) {
+  public XYLineBuilder y2(double y2) {
     this.y2 = y2;
     return this;
   }
@@ -100,7 +102,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
     return style;
   }
 
-  public XYLineAnnotationBuilder style(Stroke style) {
+  public XYLineBuilder style(Stroke style) {
     this.style = style;
     return this;
   }
@@ -109,7 +111,7 @@ public class XYLineAnnotationBuilder implements IXYAnnotationBuilder<XYLineAnnot
     return color;
   }
 
-  public XYLineAnnotationBuilder color(Paint color) {
+  public XYLineBuilder color(Paint color) {
     this.color = color;
     return this;
   }

--- a/framework/src/main/java/com/jfcbuilder/builders/XYTextBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYTextBuilder.java
@@ -27,6 +27,8 @@ import org.jfree.chart.annotations.XYAnnotation;
 import org.jfree.chart.annotations.XYTextAnnotation;
 import org.jfree.chart.ui.TextAnchor;
 
+import com.jfcbuilder.types.XYTextAnnotationElements;
+
 /**
  * Builder for producing {@link XYTextAnnotation} objects.
  */

--- a/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesBuilder.java
@@ -28,6 +28,7 @@ import org.jfree.data.general.SeriesException;
 import org.jfree.data.time.Millisecond;
 import org.jfree.data.time.TimeSeries;
 
+import com.jfcbuilder.types.XYTimeSeriesElements;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 
 /**

--- a/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesPlotBuilder.java
@@ -31,7 +31,9 @@ import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
 import org.jfree.data.time.TimeSeries;
 import org.jfree.data.time.TimeSeriesCollection;
 
+import com.jfcbuilder.adapters.NumberMappedTimeSeriesCollection;
 import com.jfcbuilder.types.Orientation;
+import com.jfcbuilder.types.XYTimeSeriesPlotBuilderElements;
 import com.jfcbuilder.types.ZeroBasedIndexRange;
 
 /**
@@ -95,8 +97,8 @@ public class XYTimeSeriesPlotBuilder implements IXYTimeSeriesPlotBuilder<XYTimeS
   }
 
   @Override
-  public XYTimeSeriesPlotBuilder line(LineBuilder line) {
-    elements.line(line);
+  public XYTimeSeriesPlotBuilder marker(MarkerBuilder line) {
+    elements.marker(line);
     return this;
   }
 
@@ -223,7 +225,7 @@ public class XYTimeSeriesPlotBuilder implements IXYTimeSeriesPlotBuilder<XYTimeS
     
     final XYPlot plot = BuilderUtils.createPlot(xAxis, yAxis, collection, renderer, elements);
 
-    for (LineBuilder builder : elements.unmodifiableLines()) {
+    for (MarkerBuilder builder : elements.unmodifiableLines()) {
       ValueMarker line = builder.build();
 
       yMax = Math.max(yMax, line.getValue());

--- a/framework/src/main/java/com/jfcbuilder/types/BuilderConstants.java
+++ b/framework/src/main/java/com/jfcbuilder/types/BuilderConstants.java
@@ -18,14 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.types;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Stroke;
-
-import com.jfcbuilder.types.Orientation;
 
 /**
  * A family of constants used throughout this builder framework.

--- a/framework/src/main/java/com/jfcbuilder/types/DohlcvSeries.java
+++ b/framework/src/main/java/com/jfcbuilder/types/DohlcvSeries.java
@@ -20,8 +20,6 @@
 
 package com.jfcbuilder.types;
 
-import com.jfcbuilder.builders.BuilderConstants;
-
 /**
  * Class for aggregating and representing a stock market Date Open High Low Close Volume (DOHLCV)
  * series. The values are stored in an individual primitive array for each component series. A

--- a/framework/src/main/java/com/jfcbuilder/types/OhlcvSeries.java
+++ b/framework/src/main/java/com/jfcbuilder/types/OhlcvSeries.java
@@ -22,8 +22,6 @@ package com.jfcbuilder.types;
 
 import java.util.Objects;
 
-import com.jfcbuilder.builders.BuilderConstants;
-
 /**
  * Class for aggregating and representing a stock market Open High Low Close Volume (OHLCV) series.
  * The values are stored in an individual primitive array for each component series. A record

--- a/framework/src/main/java/com/jfcbuilder/types/XYTextAnnotationElements.java
+++ b/framework/src/main/java/com/jfcbuilder/types/XYTextAnnotationElements.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.types;
 
 import java.awt.Color;
 import java.util.Collections;
@@ -29,7 +29,7 @@ import org.jfree.chart.ui.TextAnchor;
  * Helper class for storing and accessing properties common to different kinds of XYAnnotation builders. Intended for
  * use in composition-type implementations.
  */
-class XYTextAnnotationElements {
+public class XYTextAnnotationElements {
 
   private static final String DEFAULT_TEXT = "";
   private static final int DEFAULT_TEXT_PADDING = 0;

--- a/framework/src/main/java/com/jfcbuilder/types/XYTimeSeriesElements.java
+++ b/framework/src/main/java/com/jfcbuilder/types/XYTimeSeriesElements.java
@@ -18,19 +18,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.types;
 
 import java.awt.Color;
 import java.awt.Stroke;
 import java.util.Objects;
 
-import com.jfcbuilder.types.ZeroBasedIndexRange;
-
 /**
  * Helper class for storing and accessing properties common to different kinds of XY TimeSeries
  * builders. Intended for use in composition-type implementations.
  */
-class XYTimeSeriesElements {
+public class XYTimeSeriesElements {
 
   private static final String DEFAULT_NAME = "";
   private static final ZeroBasedIndexRange DEFAULT_INDEX_RANGE = new ZeroBasedIndexRange(0, 0);

--- a/framework/src/main/java/com/jfcbuilder/types/XYTimeSeriesPlotBuilderElements.java
+++ b/framework/src/main/java/com/jfcbuilder/types/XYTimeSeriesPlotBuilderElements.java
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package com.jfcbuilder.builders;
+package com.jfcbuilder.types;
 
 import java.awt.Paint;
 import java.text.NumberFormat;
@@ -32,13 +32,17 @@ import org.jfree.chart.axis.ValueAxis;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.data.Range;
 
-import com.jfcbuilder.types.ZeroBasedIndexRange;
+import com.jfcbuilder.builders.BuilderUtils;
+import com.jfcbuilder.builders.IXYAnnotationBuilder;
+import com.jfcbuilder.builders.IXYTimeSeriesBuilder;
+import com.jfcbuilder.builders.IXYTimeSeriesDatasetBuilder;
+import com.jfcbuilder.builders.MarkerBuilder;
 
 /**
  * Helper class for storing and accessing properties common to different kinds of XY plot builders.
  * Intended for use in composition-type implementations.
  */
-class XYTimeSeriesPlotBuilderElements {
+public class XYTimeSeriesPlotBuilderElements {
 
   /**
    * Value used to indicate the default y-axis tick size should be used.
@@ -55,7 +59,7 @@ class XYTimeSeriesPlotBuilderElements {
   
   private List<IXYTimeSeriesBuilder<?>> seriesBuilders;
   private List<IXYTimeSeriesDatasetBuilder<?>> datasetBuilders;
-  private List<LineBuilder> lineBuilders;
+  private List<MarkerBuilder> markerBuilders;
   private List<IXYAnnotationBuilder<?>> annotationBuilders;
   private ValueAxis xAxis;
   private long[] timeData;
@@ -77,7 +81,7 @@ class XYTimeSeriesPlotBuilderElements {
   public XYTimeSeriesPlotBuilderElements() {
     seriesBuilders = new ArrayList<>();
     datasetBuilders = new ArrayList<>();
-    lineBuilders = new ArrayList<>();
+    markerBuilders = new ArrayList<>();
     annotationBuilders = new ArrayList<>();
     xAxis = null;
     timeData = null;
@@ -211,23 +215,23 @@ class XYTimeSeriesPlotBuilderElements {
   }
 
   /**
-   * Registers a fixed line builder to be used for building the plot.
+   * Registers a fixed marker builder to be used for building the plot.
    * 
-   * @param line The builder to be registered
+   * @param marker The builder to be registered
    */
-  public void line(LineBuilder line) {
-    if (line != null) {
-      lineBuilders.add(line);
+  public void marker(MarkerBuilder marker) {
+    if (marker != null) {
+      markerBuilders.add(marker);
     }
   }
 
   /**
-   * Gets an unmodifiable list of the line builders to be used for building the plot.
+   * Gets an unmodifiable list of the marker builders to be used for building the plot.
    * 
-   * @return The unmodifiable list of line builders
+   * @return The unmodifiable list of marker builders
    */
-  public List<LineBuilder> unmodifiableLines() {
-    return Collections.unmodifiableList(lineBuilders);
+  public List<MarkerBuilder> unmodifiableLines() {
+    return Collections.unmodifiableList(markerBuilders);
   }
 
   /**


### PR DESCRIPTION
A bit of house-keeping to cleanup the codebase.

* **(Breaking change)** Rename LineBuilder to MarkerBuilder for reflecting the underlying jfreechart ValueMarker.
* **(Breaking change)** Rename XYLineAnnotationBuilder to XYLineBuilder for consistency with annotation builder names.
* **(Breaking change)** IXYTimeSeriesPlotBuilder's line() method renamed to marker()
* **(Breaking change)** XYTimeSeriesPlotBuilder and XYTimeSeriesPlotBuilderElements "line" references renamed to "marker"
* Package organization: add new adapters sub-package.
* Package organization: move data-structure classes to types sub-package.