### PR TITLE
Modifications to support Java 8 as the minimum requirement

### DIFF
--- a/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
+++ b/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
@@ -34,7 +34,9 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -106,7 +108,9 @@ public class JFreeChartBuilderDemo {
   private static final LocalDateTime endDate = LocalDateTime.now();
   private static final LocalDateTime startDate = endDate.minus(18, ChronoUnit.MONTHS);
 
-  private static final Set<DayOfWeek> ohlcvSkipDays = Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+  // Java 8 min requirement can't use Set.of()
+  public static DayOfWeek[] OHLCV_SKIP_DAYS = {DayOfWeek.SATURDAY, DayOfWeek.SUNDAY};
+  private static final Set<DayOfWeek> ohlcvSkipDays = new HashSet<>(Arrays.asList(OHLCV_SKIP_DAYS));
 
   private static IDateTimeSeriesProvider timeProvider = AscendingDateTimeGenerator.get();
 

--- a/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/IXYTimeSeriesPlotBuilder.java
@@ -191,8 +191,10 @@ public interface IXYTimeSeriesPlotBuilder<T extends IXYTimeSeriesPlotBuilder<T>>
    * 
    * @deprecated This facility is replaced by {@link IXYTimeSeriesPlotBuilder#majorGrid(boolean)} and
    *             {@link IXYTimeSeriesPlotBuilder#minorGrid(boolean)}, and will be removed in a future release.
+   *             <p>
+   *             <b>For removal since v1.5.7</b>
    */
-  @Deprecated(since = "1.5.7", forRemoval = true)
+  @Deprecated
   T gridLines();
 
   /**

--- a/framework/src/main/java/com/jfcbuilder/builders/OhlcPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/OhlcPlotBuilder.java
@@ -202,8 +202,10 @@ public class OhlcPlotBuilder implements IXYTimeSeriesPlotBuilder<OhlcPlotBuilder
    * 
    * @deprecated This facility is replaced by {@link OhlcPlotBuilder#majorGrid(boolean)} and
    *             {@link OhlcPlotBuilder#minorGrid(boolean)}, and will be removed in a future release.
+   *             <p>
+   *             <b>For removal since v1.5.7</b>
    */
-  @Deprecated(since = "1.5.7", forRemoval = true)
+  @Deprecated
   @Override
   public OhlcPlotBuilder gridLines() {
     elements.majorGrid(true); // Legacy behavior

--- a/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesPlotBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYTimeSeriesPlotBuilder.java
@@ -168,8 +168,10 @@ public class XYTimeSeriesPlotBuilder implements IXYTimeSeriesPlotBuilder<XYTimeS
    * 
    * @deprecated This facility is replaced by {@link XYTimeSeriesPlotBuilder#majorGrid(boolean)} and
    *             {@link XYTimeSeriesPlotBuilder#minorGrid(boolean)}, and will be removed in a future release.
+   *             <p>
+   *             <b>For removal since v1.5.7</b>
    */
-  @Deprecated(since = "1.5.7", forRemoval = true)
+  @Deprecated
   @Override
   public XYTimeSeriesPlotBuilder gridLines() {
     elements.majorGrid(true); // Legacy behavior


### PR DESCRIPTION
Modifications to support Java 8 as the minimum requirement as per JFreeChart 1.5.3.

The build using JDK 8 was broken.

* Remove `@Deprecated` annotation elements not supported by Java 8.
* Remove use of `Set.of()` not supported by Java 8.

