### PR TITLE
Partial implementation of XYDataImageBuilder for DateAxis (with time gaps) only

### DIFF
--- a/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
+++ b/demo-app/src/main/java/com/jfcbuilder/demo/JFreeChartBuilderDemo.java
@@ -67,6 +67,7 @@ import com.jfcbuilder.builders.VolumeXYPlotBuilder;
 import com.jfcbuilder.builders.VolumeXYTimeSeriesBuilder;
 import com.jfcbuilder.builders.XYArrowBuilder;
 import com.jfcbuilder.builders.XYBoxBuilder;
+import com.jfcbuilder.builders.XYDataImageBuilder;
 import com.jfcbuilder.builders.XYDrawableBuilder;
 import com.jfcbuilder.builders.XYImageBuilder;
 import com.jfcbuilder.builders.XYLineBuilder;
@@ -513,8 +514,13 @@ public class JFreeChartBuilderDemo {
           .x(p7Date).y(p7High).displayHeight(20).displayWidth(60))
         
         .annotation(XYImageBuilder.get().image(img1)
-            .x(p7Date).y(1.05 * p5High).anchor(RectangleAnchor.TOP))
-        
+          .x(p7Date).y(1.05 * p5High).anchor(RectangleAnchor.TOP))
+
+        .annotation(XYDataImageBuilder.get().image(img2)
+          .x(p1Date).y(1.05 * p5High)
+          .width(p2Date - p1Date).height(0.5)
+          .includeInDataBounds(true))
+
         .marker(MarkerBuilder.get().horizontal().at(resistanceLevel)
           .color(Color.LIGHT_GRAY).style(SOLID_LINE));
 
@@ -554,6 +560,10 @@ public class JFreeChartBuilderDemo {
         
         .annotation(XYImageBuilder.get().x(p7Date).y(p5Volume).image(img2))
         
+        .annotation(XYDataImageBuilder.get().image(img3)
+            .x(p1Date).y(1.05 * p5Volume)
+            .width(p2Date - p1Date).height(0.5 * p5Volume))
+        
         .marker(MarkerBuilder.get().horizontal().at(volumeLine)
           .color(DARK_GREEN).style(SOLID_LINE));
 
@@ -587,7 +597,11 @@ public class JFreeChartBuilderDemo {
           .drawable(new ColorBlock(TRANSPARENT_YELLOW, 1, 1))
           .x(p7Date).y(p7Stoch).displayHeight(20).displayWidth(60))
       
-        .annotation(XYImageBuilder.get().x(p7Date).y(p1Stoch).image(img3));
+        .annotation(XYImageBuilder.get().x(p7Date).y(p1Stoch).image(img3))
+      
+        .annotation(XYDataImageBuilder.get().image(img1)
+          .x(p1Date).y(1.05 * p5Stoch)
+          .width(p2Date - p1Date).height(30.0));
     }
     
     chart.xyPlot(ohlcPlot);

--- a/framework/src/main/java/com/jfcbuilder/builders/XYDataImageBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYDataImageBuilder.java
@@ -1,0 +1,177 @@
+/*
+ * jfreechart-builder: a builder pattern module for working with the jfreechart library
+ * 
+ * (C) Copyright 2022, by Matt E. and project contributors
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.jfcbuilder.builders;
+
+import java.awt.Image;
+
+import org.jfree.chart.annotations.XYAnnotation;
+import org.jfree.chart.annotations.XYDataImageAnnotation;
+
+/**
+ * Builder for producing {@link XYDataImageAnnotation} objects.
+ * <p>
+ * <b>Note: Limited to working with {@link org.jfree.chart.axis.DateAxis} (i.e. with time gaps) mode
+ * only. See related comments in mapXToTimeIndex(long[], int, int)</b>
+ * 
+ * @see XYDataImageBuilder#mapXToTimeIndex(long[], int, int)
+ */
+public class XYDataImageBuilder implements IXYAnnotationBuilder<XYDataImageBuilder> {
+
+  // See XYDataImageAnnotation for this default
+  private static final boolean DEFAULT_INCLUDE_IN_DATA_BOUNDS = false;
+
+  private double x;
+  private double y;
+  private Image image;
+  double width;
+  private double height;
+  private boolean includeInDataBounds;
+
+  /**
+   * Hidden constructor.
+   */
+  private XYDataImageBuilder() {
+    x = Double.NaN;
+    y = Double.NaN;
+    image = null;
+    width = Double.NaN;
+    height = Double.NaN;
+    includeInDataBounds = DEFAULT_INCLUDE_IN_DATA_BOUNDS;
+  }
+
+  /**
+   * Factory method for obtaining new instances of this class.
+   * 
+   * @return New instance of this class
+   */
+  public static XYDataImageBuilder get() {
+    return new XYDataImageBuilder();
+  }
+
+  public XYDataImageBuilder x(double x) {
+    this.x = x;
+    return this;
+  }
+
+  public double x() {
+    return x;
+  }
+
+  public XYDataImageBuilder y(double y) {
+    this.y = y;
+    return this;
+  }
+
+  public double y() {
+    return y;
+  }
+
+  public XYDataImageBuilder image(Image image) {
+    this.image = image;
+    return this;
+  }
+
+  public Image image() {
+    return image;
+  }
+
+  public XYDataImageBuilder width(double w) {
+    width = w;
+    return this;
+  }
+
+  public double width() {
+    return width;
+  }
+
+  public XYDataImageBuilder height(double h) {
+    height = h;
+    return this;
+  }
+
+  public double height() {
+    return height;
+  }
+  
+  public XYDataImageBuilder includeInDataBounds(boolean include) {
+    includeInDataBounds = include;
+    return this;
+  }
+
+  public boolean includeInDataBounds() {
+    return includeInDataBounds;
+  }
+
+  private void checkBuildPreconditions() throws IllegalStateException {
+
+    if (Double.isNaN(x) || Double.isNaN(y)) {
+      throw new IllegalStateException("X or Y value not set");
+    }
+
+    if (image == null) {
+      throw new IllegalStateException("Image not set");
+    }
+    
+    if (Double.isNaN(width) || Double.isNaN(height)) {
+      throw new IllegalStateException("Width or height not set");
+    }
+  }
+
+  @Override
+  public XYAnnotation build() throws IllegalStateException {
+
+    checkBuildPreconditions();
+
+    return new XYDataImageAnnotation(image, x, y, width, height, includeInDataBounds);
+  }
+
+
+  @Override
+  public void mapXToTimeIndex(long[] timeData, int indexRangeStartIndex, int indexRangeEndIndex) {
+
+    // Gapless XYDataImageAnnotation is not currently supported due to conversion of the width.
+    //
+    // It's believed we need to somehow map the width to a number of numeric indices but the
+    // configured width in the time domain can be fractional in the integer index domain.
+    //
+    // Instead of providing a best fit guess that could leave users wanting, this capability is left
+    // unimplemented.
+    //
+    // If one really needs this one can try extending this class and overriding the
+    // mapXToTimeIndex() method to write their own logic.
+    //
+    // There's a potential code snippet below inspired from the other builders.
+    
+    /*
+    // +1 as the binary search method end index is exclusive.
+    int xIndex = Arrays.binarySearch(timeData, indexRangeStartIndex, indexRangeEndIndex + 1,
+        (long) x());
+
+    if (xIndex >= 0) {
+      x((double) (xIndex - indexRangeStartIndex));
+      
+      // And now how many indices does the width span? All time spacing is squashed into sequential
+      // evenly spaced indices ...
+      width( width() / ??? );
+    }
+    */
+  }
+}

--- a/framework/src/main/java/com/jfcbuilder/builders/XYShapeBuilder.java
+++ b/framework/src/main/java/com/jfcbuilder/builders/XYShapeBuilder.java
@@ -31,6 +31,11 @@ import org.jfree.chart.annotations.XYShapeAnnotation;
 
 /**
  * Builder for producing {@link XYShapeAnnotation} objects.
+ * <p>
+ * <b>Note: Limited to working with {@link org.jfree.chart.axis.DateAxis} (i.e. with time gaps) mode
+ * only. See related comments in mapXToTimeIndex(long[], int, int)</b>
+ * 
+ * @see XYShapeBuilder#mapXToTimeIndex(long[], int, int)
  */
 public class XYShapeBuilder implements IXYAnnotationBuilder<XYShapeBuilder> {
 


### PR DESCRIPTION
Implements enhancement #45 but only for `DateAxis` (with time gaps).

See https://github.com/matoos32/jfreechart-builder/issues/45#issuecomment-1326649874 for discussion.